### PR TITLE
Fix MQTT reliability for Nextion displays

### DIFF
--- a/DisplayDriver.cpp
+++ b/DisplayDriver.cpp
@@ -234,6 +234,13 @@ int CDisplayDriver::run()
 		return 1;
 	}
 
+	// Pump the MQTT loop until connected (CONNACK received) so that
+	// the display startup commands don't get silently dropped.
+	for (unsigned int i = 0U; i < 50U && !m_mqtt->isConnected(); i++) {
+		m_mqtt->loop();
+		CThread::sleep(100U);
+	}
+
 #if !defined(_WIN32) && !defined(_WIN64)
 	if (m_daemon) {
 		::close(STDIN_FILENO);
@@ -257,6 +264,12 @@ int CDisplayDriver::run()
 		stopWatch.start();
 
 		m_display->clock(ms);
+
+		// Drive MQTT I/O from the main loop (non-threaded) to
+		// avoid the auto-reconnect race that causes client ID
+		// collisions and a connect/disconnect loop.
+		if (m_mqtt != nullptr)
+			m_mqtt->loop();
 
 		if (ms < 10U)
 			CThread::sleep(10U);

--- a/MQTTConnection.cpp
+++ b/MQTTConnection.cpp
@@ -23,6 +23,12 @@
 #include <cstring>
 #include <ctime>
 
+#if defined(_WIN32) || defined(_WIN64)
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
 CMQTTConnection::CMQTTConnection(const std::string& host, unsigned short port, const std::string& name, const bool authEnabled, const std::string& username, const std::string& password, const std::vector<std::pair<std::string, void (*)(const unsigned char*, unsigned int)>>& subs, unsigned int keepalive, MQTT_QOS qos) :
 m_host(host),
 m_port(port),
@@ -52,7 +58,11 @@ CMQTTConnection::~CMQTTConnection()
 bool CMQTTConnection::open()
 {
 	char name[50U];
-	::sprintf(name, "Display-Driver.%ld", ::time(nullptr));
+#if defined(_WIN32) || defined(_WIN64)
+	::sprintf(name, "Display-Driver.%u", (unsigned)::_getpid());
+#else
+	::sprintf(name, "Display-Driver.%u", (unsigned)::getpid());
+#endif
 
 	::fprintf(stdout, "Display-Driver (%s) connecting to MQTT as %s\n", m_name.c_str(), name);
 
@@ -75,15 +85,6 @@ bool CMQTTConnection::open()
 		::mosquitto_destroy(m_mosq);
 		m_mosq = nullptr;
 		::fprintf(stderr, "MQTT Error connecting: %s\n", ::mosquitto_strerror(rc));
-		return false;
-	}
-
-	rc = ::mosquitto_loop_start(m_mosq);
-	if (rc != MOSQ_ERR_SUCCESS) {
-		::mosquitto_disconnect(m_mosq);
-		::mosquitto_destroy(m_mosq);
-		m_mosq = nullptr;
-		::fprintf(stderr, "MQTT Error loop starting: %s\n", ::mosquitto_strerror(rc));
 		return false;
 	}
 
@@ -131,6 +132,25 @@ bool CMQTTConnection::publish(const char* topic, const unsigned char* data, unsi
 	}
 
 	return true;
+}
+
+int CMQTTConnection::loop()
+{
+	if (m_mosq == nullptr)
+		return -1;
+
+	int rc = ::mosquitto_loop(m_mosq, 0, 1);
+	if (rc != MOSQ_ERR_SUCCESS && rc != MOSQ_ERR_NO_CONN) {
+		// Connection lost — try to reconnect.
+		::mosquitto_reconnect(m_mosq);
+	}
+
+	return rc;
+}
+
+bool CMQTTConnection::isConnected() const
+{
+	return m_connected;
 }
 
 void CMQTTConnection::close()

--- a/MQTTConnection.h
+++ b/MQTTConnection.h
@@ -37,6 +37,10 @@ public:
 
 	bool open();
 
+	int loop();
+
+	bool isConnected() const;
+
 	bool publish(const char* topic, const char* text);
 	bool publish(const char* topic, const std::string& text);
 	bool publish(const char* topic, const unsigned char* data, unsigned int len);

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -54,10 +54,11 @@ m_idleBrightness(idleBrightness),
 m_screenLayout(0),
 m_clockDisplayTimer(1000U, 0U, 400U),
 m_displayTempInF(displayTempInF),
-m_output(200U, "Nextion buffer"),
+m_output(2000U, "Nextion buffer"),
 m_mutex(),
 m_reply(nullptr),
-m_waiting(false)
+m_waiting(false),
+m_waitingTimer(1000U, 0U, 500U)
 {
 	assert(serial != nullptr);
 	assert(brightness >= 0U && brightness <= 100U);
@@ -734,21 +735,35 @@ void CNextion::clockInt(unsigned int ms)
 	// Update the clock display in IDLE mode every 400ms
 	m_clockDisplayTimer.clock(ms);
 	if (m_displayClock && (m_mode == MODE_IDLE || m_mode == MODE_CW) && m_clockDisplayTimer.isRunning() && m_clockDisplayTimer.hasExpired()) {
-		time_t currentTime;
-		struct tm *Time;
-		::time(&currentTime);                   // Get the current time
+		// Skip clock update if the output buffer is more than half full.
+		// Over MQTT the drain rate is much slower than direct serial, so
+		// piling on timer commands can cause buffer overflow.
+		if (m_output.freeSpace() > 100U) {
+			time_t currentTime;
+			struct tm *Time;
+			::time(&currentTime);                   // Get the current time
 
-		if (m_utc)
-			Time = ::gmtime(&currentTime);
-		else
-			Time = ::localtime(&currentTime);
+			if (m_utc)
+				Time = ::gmtime(&currentTime);
+			else
+				Time = ::localtime(&currentTime);
 
-		::setlocale(LC_TIME,"");
-		char text[50U];
-		::strftime(text, 50, "t2.txt=\"%x %X\"", Time);
-		sendCommand(text);
+			::setlocale(LC_TIME,"");
+			char text[50U];
+			::strftime(text, 50, "t2.txt=\"%x %X\"", Time);
+			sendCommand(text);
+		}
 
 		m_clockDisplayTimer.start(); // restart the clock display timer
+	}
+
+	// Timeout stale waits — over MQTT, responses can be lost or delayed.
+	// Without this, m_waiting stays true forever and the queue never drains.
+	m_waitingTimer.clock(ms);
+	if (m_waiting && m_waitingTimer.isRunning() && m_waitingTimer.hasExpired()) {
+		LogDebug("Nextion response timeout, resuming queue");
+		m_waiting = false;
+		m_waitingTimer.stop();
 	}
 
 	unsigned char c;
@@ -788,6 +803,7 @@ void CNextion::clockInt(unsigned int ms)
 			}
 
 			m_waiting = false;
+			m_waitingTimer.stop();
 			break;
 		}
 	}
@@ -809,6 +825,7 @@ void CNextion::clockInt(unsigned int ms)
 			m_serial->write(buffer, len);
 
 			m_waiting = true;
+			m_waitingTimer.start();
 		}
 	}
 }

--- a/Nextion.h
+++ b/Nextion.h
@@ -101,6 +101,7 @@ private:
 	CMutex         m_mutex;
 	unsigned char* m_reply;
 	bool           m_waiting;
+	CTimer         m_waitingTimer;
 
 	void sendCommand(const std::string& command);
 	void sendCommandAction(unsigned int status);


### PR DESCRIPTION
## Summary

When DisplayDriver communicates with a Nextion display via the MMDVM serial passthrough (`Port=modem`) over MQTT, three related issues cause the display to stop updating and eventually overflow its command buffer.

This patch fixes all three. The changes are safe for direct serial (`Port=/dev/ttyUSB*`) configurations — the timeout cannot fire under normal serial latency, the larger buffer is just extra headroom, and the MQTT loop change is more predictable than the threaded alternative for all configurations.

## Bug 1: Output buffer overflow

The 200-byte `m_output` ring buffer is too small for the MQTT path. Over direct serial, commands are sent and acknowledged in milliseconds so the buffer rarely holds more than one command. Over MQTT, the round-trip through `DisplayDriver → mosquitto → MMDVMHost → MMDVM firmware → Nextion → back` adds significant latency. Commands queue faster than they drain, and the buffer overflows:

```
E: Nextion buffer buffer overflow, clearing the buffer. (19 >= 2)
```

**Fix:** Increased buffer from 200 to 2000 bytes. Added a `freeSpace()` guard on the clock update timer — if the buffer is more than half full, clock commands are skipped rather than contributing to the overflow.

## Bug 2: `m_waiting` stuck forever (no response timeout)

The Nextion code uses a stop-and-wait protocol: `clockInt()` sends one command from the queue, sets `m_waiting = true`, and waits for a `0xFF 0xFF 0xFF`-terminated response before sending the next. There is no timeout — if a response is lost or delayed via MQTT, `m_waiting` stays `true` permanently. The queue never drains, new commands accumulate, and the buffer eventually overflows (Bug 1).

**Fix:** Added a 500ms `CTimer` (`m_waitingTimer`) that resets `m_waiting = false` if no response arrives, allowing the next queued command to be sent. The timer is started when a command is sent and stopped when a response arrives. On direct serial, responses arrive in 1–5ms so the timeout never fires.

## Bug 3: MQTT client ID collision causing connect/disconnect loop

The client ID is generated with:
```cpp
::sprintf(name, "Display-Driver.%ld", ::time(nullptr));
```

On ARM platforms with a 64-bit kernel and 32-bit userland (e.g. Raspberry Pi OS, some Alpine Linux builds using musl libc), `time_t` is a 64-bit type (`long long` on musl, `__time64_t` on newer glibc) but `%ld` reads only 32 bits. On current timestamps the low 32 bits are zero, producing `"Display-Driver.0"` every time.

When `mosquitto_loop_start()`'s background thread auto-reconnects, it opens a new connection with the same client ID. The broker (correctly) disconnects the old session, the old session reconnects, kicks the new one, and so on — an infinite connect/disconnect loop:

```
MQTT: on_connect: Connection Accepted.
MQTT: on_disconnect: Success
MQTT: on_connect: Connection Accepted.
MQTT: on_disconnect: Success
...
```

**Fix:** Switched to `getpid()` for a unique client ID — `pid_t` is always `int` on every POSIX platform, so there's no width mismatch. Added proper Windows guards (`_getpid()` from `<process.h>`). Also replaced the threaded `mosquitto_loop_start()` with manual `mosquitto_loop()` called from the main loop, eliminating the auto-reconnect race entirely. Added a startup wait loop that pumps `mosquitto_loop()` until connected, so display startup commands aren't silently dropped.

## Files Changed

| File | Change |
|------|--------|
| `Nextion.h` | Added `m_waitingTimer` member |
| `Nextion.cpp` | Buffer 200→2000, freeSpace guard on clock, 500ms response timeout |
| `MQTTConnection.h` | Added `loop()` and `isConnected()` declarations |
| `MQTTConnection.cpp` | PID-based client ID (Windows-portable), removed `mosquitto_loop_start()`, added manual `loop()` and `isConnected()` |
| `DisplayDriver.cpp` | Call `m_mqtt->loop()` from main loop, wait for MQTT connection at startup |

## Testing

Tested on a Raspberry Pi with a SkyBridge MMDVM modem and NX3224T024 Nextion display connected via GPIO UART (`/dev/ttyAMA0`). DisplayDriver configured with `Port=modem` (MQTT serial passthrough). Before the fix: buffer overflows within minutes, display blank. After the fix: stable operation, Nextion responds to commands, no buffer overflows.